### PR TITLE
chore: remove scope section in default PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,14 +14,6 @@ Context or motivation for this change.
 
 High-level explanation of the solution.
 
-## Scope
-
-- [ ] Feature
-- [ ] Bugfix
-- [ ] Refactor
-- [ ] Chore
-- [ ] Style
-
 ## Linked Issue
 
 Closes #


### PR DESCRIPTION
## What

Remove the `Scope` section from the pull request template.

## Why

In most cases, the PR title already provides enough context about the type of change.
Keeping a separate scope section was redundant and added unnecessary friction when opening PRs.

## How

Updated the pull request template by removing the `Scope` section and its checkboxes, simplifying the PR creation flow.

## Linked Issue

Closes #

## Checklist

- [] Code follows project standards
- [x] Manual validation performed
- [ ] Tests added or updated (not applicable)
- [ ] Documentation updated (not needed)